### PR TITLE
refactor: switch from turnkey ethers to turnkey viem (lighter & faster)

### DIFF
--- a/packages/accounts/package.json
+++ b/packages/accounts/package.json
@@ -44,7 +44,9 @@
     "test:run": "vitest run"
   },
   "devDependencies": {
-    "@turnkey/ethers": "^0.16.5",
+    "@turnkey/api-key-stamper": "^0.1.1",
+    "@turnkey/http": "^1.2.0",
+    "@turnkey/viem": "^0.2.4",
     "typescript": "^5.0.4",
     "typescript-template": "*",
     "vitest": "^0.31.0"

--- a/packages/accounts/src/kernel-zerodev/owner/getCustodialOwner.ts
+++ b/packages/accounts/src/kernel-zerodev/owner/getCustodialOwner.ts
@@ -4,6 +4,25 @@ import axios from "axios";
 import {TurnkeyClient} from "@turnkey/http";
 
 /**
+ * Params to get a custodial owner
+ * Priv / pub key combo or custodial file path should be in different types
+ */
+type GetCustodialOwnerParams = {
+  // ZeroDev api url
+  apiUrl?: string;
+  // Turnkey client (if the client want to reuse it
+  turnKeyClient?: TurnkeyClient;
+
+  // Direct access to priv / pub key
+  privateKey?: string;
+  publicKey?: string;
+  keyId?: string;
+
+  // Or read them from the custodial file path
+  custodialFilePath?: string;
+}
+
+/**
  * Returns a signer for a custodial wallet via TurnKey
  */
 export async function getCustodialOwner(
@@ -15,14 +34,7 @@ export async function getCustodialOwner(
     keyId,
     apiUrl = API_URL,
     turnKeyClient,
-  }: {
-    privateKey?: string;
-    publicKey?: string;
-    keyId?: string;
-    custodialFilePath?: string;
-    apiUrl?: string;
-    turnKeyClient?: TurnkeyClient;
-  }
+  }: GetCustodialOwnerParams
 ): Promise<SmartAccountSigner | undefined> {
   // Extract data from the custodial file path if provided
   if (custodialFilePath) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3917,20 +3917,36 @@
     "@tufjs/canonical-json" "1.0.0"
     minimatch "^9.0.0"
 
-"@turnkey/ethers@^0.16.5":
-  version "0.16.5"
-  resolved "https://registry.yarnpkg.com/@turnkey/ethers/-/ethers-0.16.5.tgz#1ec887d64fcae87f67863a27587f31b044b15421"
-  integrity sha512-g33kCZowrh62qUCCvcG4EsDuv86sOaY0oyyeu7B39DS9xq2Oj8YDNPVh9JefKRgQaSbAmt3INz768FNAEJDCDA==
-  dependencies:
-    "@ethersproject/abstract-signer" "^5.7.0"
-    "@turnkey/http" "1.0.1"
+"@turnkey/api-key-stamper@0.1.1", "@turnkey/api-key-stamper@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@turnkey/api-key-stamper/-/api-key-stamper-0.1.1.tgz#7a5b5cd9cee7bd05059b87ccf66bfc264dbbd8a0"
+  integrity sha512-qs8fmWFiAhh7fAByx7j9/2F0VRe/qD7Yq3hi4FwD+jLU0CXdE+aim1cmJpAFFPKF1PBmPs6jh4XBODE40eqEEg==
 
-"@turnkey/http@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@turnkey/http/-/http-1.0.1.tgz#21aadcbbe67c60278ce187bbe6642ffa614e7779"
-  integrity sha512-Tp2SKHeZa03HYMnXDFfAUw1akS+VBwTKOqKe2GOusLVQAcOXMhLIXCjipRkAfYynD/kDXPkr8sEVhDXxdSejsw==
+"@turnkey/http@1.3.0", "@turnkey/http@^1.2.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@turnkey/http/-/http-1.3.0.tgz#c21389d0997a305888911b345fdcf44f16dd7878"
+  integrity sha512-vl/z3GSRY5ZvjHvb7gpfyq8HXj630yYViHqtstTRtGCv1QaNxgsDzZ/ECkN8fWiJJj/4SUiiKw6jSeHL0jTAew==
   dependencies:
+    "@turnkey/api-key-stamper" "0.1.1"
+    "@turnkey/webauthn-stamper" "0.2.0"
     cross-fetch "^3.1.5"
+
+"@turnkey/viem@^0.2.4":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@turnkey/viem/-/viem-0.2.5.tgz#a4059d4cd43cbb80330cb7b78330ea7a58d42db7"
+  integrity sha512-HdXI0oi/7MfEEHDtIUjjG27/WotZBVLb8NzmqKzSnyiDvBC0UX4toba6pobKngxtehg/5DznJW961d7CRAx2Gw==
+  dependencies:
+    "@turnkey/api-key-stamper" "0.1.1"
+    "@turnkey/http" "1.3.0"
+    cross-fetch "^4.0.0"
+    typescript "5.1"
+
+"@turnkey/webauthn-stamper@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@turnkey/webauthn-stamper/-/webauthn-stamper-0.2.0.tgz#aa546391ee59cf6c5d4201d74e038adb261765d2"
+  integrity sha512-BoHucuoTTmvqJzqSZs6XsLHSu1rwelSHUFBDlUfYX/QzK9BpkaxMxamOxk92OLpRb6qRUngrCQeS/jPHlWgQow==
+  dependencies:
+    buffer "^6.0.3"
 
 "@types/bn.js@^5.1.0":
   version "5.1.1"
@@ -5980,6 +5996,13 @@ cross-fetch@^3.1.4, cross-fetch@^3.1.5:
   integrity sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==
   dependencies:
     node-fetch "^2.6.11"
+
+cross-fetch@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-4.0.0.tgz#f037aef1580bb3a1a35164ea2a848ba81b445983"
+  integrity sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==
+  dependencies:
+    node-fetch "^2.6.12"
 
 cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
@@ -9385,6 +9408,13 @@ node-fetch@^2.6.11, node-fetch@^2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
+node-fetch@^2.6.12:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-fetch@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.1.tgz#b3eea7b54b3a48020e46f4f88b9c5a7430d20b2e"
@@ -11799,6 +11829,11 @@ typescript-template@*:
   integrity sha512-j+01BVN+beFVnW768Is/tJ8rqwEE+a1dqlDayuAcsEn56KkBgCqJgIfMk1t0Xg99VyaWmpE+AItNtnio+eeWEA==
   dependencies:
     sitka "^1.0.6"
+
+typescript@5.1:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
+  integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
 
 "typescript@^3 || ^4":
   version "4.9.5"


### PR DESCRIPTION
Remove the dependency to TurnKey ethers
Add the required dependencies to use turnkey viem turnkey/(http | stamper | viem)
Move a bit the logic inside the `getCustodialOwner` method to be more readable.
Add a few comments.