### PR TITLE
refactor: update turnkey & add a bit of caching in `getCustodialOwner()` method

### DIFF
--- a/packages/accounts/package.json
+++ b/packages/accounts/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@turnkey/api-key-stamper": "^0.1.1",
-    "@turnkey/http": "^1.2.0",
+    "@turnkey/http": "^2.1.0",
     "@turnkey/viem": "^0.2.4",
     "typescript": "^5.0.4",
     "typescript-template": "*",
@@ -65,10 +65,11 @@
   "homepage": "https://github.com/zerodevapp/sdk/blob/main/README.md#readme",
   "gitHead": "19ba05a77e4f7a0e04f44f34eaecf675fe2c12f2",
   "dependencies": {
+    "@alchemy/aa-core": "0.1.0-alpha.23",
+    "@alchemy/aa-ethers": "0.1.0-alpha.23",
     "axios": "^1.4.0",
     "merkletreejs": "^0.3.10",
-    "viem": "^1.5.3",
-    "@alchemy/aa-core": "0.1.0-alpha.23",
-    "@alchemy/aa-ethers": "0.1.0-alpha.23"
+    "radash": "^11.0.0",
+    "viem": "^1.5.3"
   }
 }

--- a/packages/accounts/src/kernel-zerodev/owner/getCustodialOwner.ts
+++ b/packages/accounts/src/kernel-zerodev/owner/getCustodialOwner.ts
@@ -1,8 +1,8 @@
-import type {SignTypedDataParams, SmartAccountSigner} from "@alchemy/aa-core";
-import {API_URL} from "../constants.js";
+import type { SignTypedDataParams, SmartAccountSigner } from "@alchemy/aa-core";
+import { API_URL } from "../constants.js";
 import axios from "axios";
-import {TurnkeyClient} from "@turnkey/http";
-import {memo, tryit} from "radash";
+import { TurnkeyClient } from "@turnkey/http";
+import { memo, tryit } from "radash";
 
 /**
  * Params to get a custodial owner
@@ -39,24 +39,27 @@ export async function getCustodialOwner(
 ): Promise<SmartAccountSigner | undefined> {
   // Extract data from the custodial file path if provided
   if (custodialFilePath) {
-    [privateKey, publicKey, keyId] = await loadSignDataFromCustodialFile(custodialFilePath);
+    [privateKey, publicKey, keyId] = await loadSignDataFromCustodialFile(
+      custodialFilePath
+    );
   }
 
   // Ensure we have the required values
-  if (!keyId || ((!privateKey || !publicKey) && (!turnKeyClient))) {
+  if (!keyId || ((!privateKey || !publicKey) && !turnKeyClient)) {
     throw new Error(
       "Must provide custodialFilePath or privateKey, publicKey, and keyId, or a keyId and a turnkeyClient."
     );
   }
 
   // Get our turnkey client (build it if needed)
-  const ensuredTurnkeyClient = turnKeyClient ?? await getDefaultTurnkeyClient({privateKey, publicKey});
+  const ensuredTurnkeyClient =
+    turnKeyClient ?? (await getDefaultTurnkeyClient({ privateKey, publicKey }));
   if (!ensuredTurnkeyClient) {
     throw new Error("No turnkey client available");
   }
 
   // Get the wallet identifier from the API
-  const response = await fetchWallet({identifier, keyId, apiUrl});
+  const response = await fetchWallet({ identifier, keyId, apiUrl });
   if (!response?.data?.walletId) {
     throw new Error(`No wallet id found for ${identifier}`);
   }
@@ -66,7 +69,7 @@ export async function getCustodialOwner(
     keyId,
     privateKeyId: response.data.walletId,
     turnkeyClient: ensuredTurnkeyClient,
-  })
+  });
 
   // Return an alchemy AA signer from the turnkey signer
   return {
@@ -88,89 +91,146 @@ export async function getCustodialOwner(
 /**
  * Try to load sign data from a local custodial file path
  */
-const loadSignDataFromCustodialFile = memo(async (custodialFilePath: string) => {
-    const [,fsModule] = await tryit(() => import("fs"))();
+const loadSignDataFromCustodialFile = memo(
+  async (custodialFilePath: string) => {
+    const [, fsModule] = await tryit(() => import("fs"))();
     if (!fsModule) {
-        console.log("FS module not available. Skipping FS operation...");
-        return;
+      console.log("FS module not available. Skipping FS operation...");
+      return;
     }
     const data = fsModule.readFileSync(custodialFilePath, "utf8");
     return data.split("\n");
-}, {
-    // TTL of 30sec, to avoid reading the file too often
-    ttl: 1000 * 30,
+  },
+  {
+    // TTL of 1min in the memory cache
+    ttl: 1000 * 60,
     // The key in the cache
-    key: (custodialFilePath: string) => `${custodialFilePath}`
-});
+    key: (custodialFilePath: string) => `${custodialFilePath}`,
+  }
+);
 
 /**
  * Get our default turnkey client
  */
-const getDefaultTurnkeyClient = memo(async ({privateKey, publicKey}: {privateKey: string, publicKey: string}) => {
+const getDefaultTurnkeyClient = memo(
+  async ({
+    privateKey,
+    publicKey,
+  }: {
+    privateKey: string;
+    publicKey: string;
+  }) => {
     // Try to fetch turnkey client & api key stamper
     const [, turnkeyHttp] = await tryit(() => import("@turnkey/http"))();
-    const [, turnkeyApiKeyStamper] = await tryit(() =>
-        import("@turnkey/api-key-stamper")
+    const [, turnkeyApiKeyStamper] = await tryit(
+      () => import("@turnkey/api-key-stamper")
     )();
     if (!turnkeyHttp || !turnkeyApiKeyStamper) {
-        console.log(
-            "@turnkey/http or @turnkey/api-key-stamper module not available. Skipping FS operation..."
-        );
-        return;
+      console.log(
+        "@turnkey/http or @turnkey/api-key-stamper module not available. Skipping FS operation..."
+      );
+      return;
     }
 
     // Build the turnkey client
     return new turnkeyHttp.TurnkeyClient(
-        {
-            baseUrl: "https://api.turnkey.com",
-        },
-        new turnkeyApiKeyStamper.ApiKeyStamper({
-            apiPublicKey: publicKey,
-            apiPrivateKey: privateKey,
-        })
+      {
+        baseUrl: "https://api.turnkey.com",
+      },
+      new turnkeyApiKeyStamper.ApiKeyStamper({
+        apiPublicKey: publicKey,
+        apiPrivateKey: privateKey,
+      })
     );
-}, {
+  },
+  {
     // TTL of 1min in the memory cache
     ttl: 1000 * 60,
     // The key in the cache
-    key: ({privateKey, publicKey}: {privateKey: string, publicKey: string}) => `${privateKey}-${publicKey}`
-});
+    key: ({
+      privateKey,
+      publicKey,
+    }: {
+      privateKey: string;
+      publicKey: string;
+    }) => `${privateKey}-${publicKey}`,
+  }
+);
 
 /**
  * Simple function used to fetch the wallet id from the API using an identifier
  */
-const fetchWallet = memo(({identifier, keyId, apiUrl}: {identifier: string, keyId: string, apiUrl: string}) => {
+const fetchWallet = memo(
+  ({
+    identifier,
+    keyId,
+    apiUrl,
+  }: {
+    identifier: string;
+    keyId: string;
+    apiUrl: string;
+  }) => {
     return axios.post<any, { data: { walletId: string } }>(
-        `${apiUrl}/wallets/${identifier}`,
-        {
+      `${apiUrl}/wallets/${identifier}`,
+      {
         keyId,
-        }
+      }
     );
-}, {
-  // TTL of 1 day
-  ttl: 1000 * 60 * 60 * 24,
-  // The key in the cache
-  key: ({identifier, keyId, apiUrl}: {identifier: string, keyId: string, apiUrl: string}) => `${identifier}-${keyId}-${apiUrl}`
-});
+  },
+  {
+    // TTL of 1min in the memory cache
+    ttl: 1000 * 60,
+    // The key in the cache
+    key: ({
+      identifier,
+      keyId,
+      apiUrl,
+    }: {
+      identifier: string;
+      keyId: string;
+      apiUrl: string;
+    }) => `${identifier}-${keyId}-${apiUrl}`,
+  }
+);
 
 /**
  * Get a turnkey signer
  */
-const getTurnkeySigner = memo(async ({keyId, privateKeyId, turnkeyClient}: {keyId: string, privateKeyId: string, turnkeyClient: TurnkeyClient}) => {
+const getTurnkeySigner = memo(
+  async ({
+    keyId,
+    privateKeyId,
+    turnkeyClient,
+  }: {
+    keyId: string;
+    privateKeyId: string;
+    turnkeyClient: TurnkeyClient;
+  }) => {
     // Get the turnkey viem account
     const [, turnkeyViem] = await tryit(() => import("@turnkey/viem"))();
     if (!turnkeyViem) {
-        console.log("@turnkey/viem module not available. Skipping FS operation...");
-        return;
+      console.log(
+        "@turnkey/viem module not available. Skipping FS operation..."
+      );
+      return;
     }
     return turnkeyViem.createAccount({
-        client: turnkeyClient,
-        organizationId: keyId,
-        privateKeyId,
+      client: turnkeyClient,
+      organizationId: keyId,
+      privateKeyId,
     });
-}, {
-  // TTL of 1 day
-    ttl: 1000 * 60 * 60 * 24,
+  },
+  {
+    // TTL of 1min in the memory cache
+    ttl: 1000 * 60,
     // The key in the cache
-    key: ({keyId, privateKeyId}: {keyId: string, privateKeyId: string, turnkeyClient: TurnkeyClient}) => `${keyId}-${privateKeyId}`
-});
+    key: ({
+      keyId,
+      privateKeyId,
+    }: {
+      keyId: string;
+      privateKeyId: string;
+      turnkeyClient: TurnkeyClient;
+    }) => `${keyId}-${privateKeyId}`,
+  }
+);

--- a/packages/accounts/src/kernel-zerodev/owner/getCustodialOwner.ts
+++ b/packages/accounts/src/kernel-zerodev/owner/getCustodialOwner.ts
@@ -1,13 +1,14 @@
-import type { SignTypedDataParams, SmartAccountSigner } from "@alchemy/aa-core";
-import { API_URL } from "../constants.js";
+import type {SignTypedDataParams, SmartAccountSigner} from "@alchemy/aa-core";
+import {API_URL} from "../constants.js";
 import axios from "axios";
-import { TurnkeyClient } from "@turnkey/http";
+import {TurnkeyClient} from "@turnkey/http";
+import {memo, tryit} from "radash";
 
 /**
  * Params to get a custodial owner
  * Priv / pub key combo or custodial file path should be in different types
  */
-type GetCustodialOwnerParams = {
+type GetCustodialOwnerParams = Readonly<{
   // ZeroDev api url
   apiUrl?: string;
   // Turnkey client (if the client want to reuse it
@@ -20,7 +21,7 @@ type GetCustodialOwnerParams = {
 
   // Or read them from the custodial file path
   custodialFilePath?: string;
-};
+}>;
 
 /**
  * Returns a signer for a custodial wallet via TurnKey
@@ -38,81 +39,34 @@ export async function getCustodialOwner(
 ): Promise<SmartAccountSigner | undefined> {
   // Extract data from the custodial file path if provided
   if (custodialFilePath) {
-    let fsModule;
-    try {
-      fsModule = require.resolve("fs") && require("fs");
-    } catch (error) {
-      console.log("FS module not available. Skipping FS operation...");
-      return;
-    }
-    const data = fsModule.readFileSync(custodialFilePath, "utf8");
-    const values = data.split("\n");
-    // Override the values, if they are provided, to the one from the custodial file
-    [privateKey, publicKey, keyId] = values;
+    [privateKey, publicKey, keyId] = await loadSignDataFromCustodialFile(custodialFilePath);
   }
 
   // Ensure we have the required values
-  if (!privateKey || !publicKey || !keyId) {
+  if (!keyId || ((!privateKey || !publicKey) && (!turnKeyClient))) {
     throw new Error(
-      "Must provide custodialFilePath or privateKey, publicKey, and keyId."
+      "Must provide custodialFilePath or privateKey, publicKey, and keyId, or a keyId and a turnkeyClient."
     );
   }
 
   // Get our turnkey client (build it if needed)
-  if (!turnKeyClient) {
-    // Try to fetch turnkey client & api key stamper
-    let TurnkeyClient;
-    let ApiKeyStamper;
-    // TODO: Would be cleaner with something like radash and a tryit function?
-    try {
-      TurnkeyClient =
-        require.resolve("@turnkey/http") &&
-        require("@turnkey/http").TurnkeyClient;
-      ApiKeyStamper =
-        require.resolve("@turnkey/api-key-stamper") &&
-        require("@turnkey/api-key-stamper").ApiKeyStamper;
-    } catch (error) {
-      console.log(
-        "@turnkey/http or @turnkey/api-key-stamper module not available. Skipping FS operation..."
-      );
-      return;
-    }
-
-    // Build the turnkey client
-    turnKeyClient = new TurnkeyClient(
-      {
-        baseUrl: "https://api.turnkey.com",
-      },
-      new ApiKeyStamper({
-        apiPublicKey: publicKey,
-        apiPrivateKey: privateKey,
-      })
-    );
+  const ensuredTurnkeyClient = turnKeyClient ?? await getDefaultTurnkeyClient({privateKey, publicKey});
+  if (!ensuredTurnkeyClient) {
+    throw new Error("No turnkey client available");
   }
 
   // Get the wallet identifier from the API
-  const response = await axios.post<any, { data: { walletId: string } }>(
-    `${apiUrl}/wallets/${identifier}`,
-    {
-      keyId,
-    }
-  );
+  const response = await fetchWallet({identifier, keyId, apiUrl});
+  if (!response?.data?.walletId) {
+    throw new Error(`No wallet id found for ${identifier}`);
+  }
 
   // Build the turnkey viem account
-  let createAccount;
-  try {
-    createAccount =
-      require.resolve("@turnkey/viem") &&
-      require("@turnkey/viem").createAccount;
-  } catch (error) {
-    console.log("@turnkey/viem module not available. Skipping FS operation...");
-    return;
-  }
-  const turnkeySigner = await createAccount({
-    client: turnKeyClient,
-    organizationId: keyId,
+  const turnkeySigner = await getTurnkeySigner({
+    keyId,
     privateKeyId: response.data.walletId,
-  });
+    turnkeyClient: ensuredTurnkeyClient,
+  })
 
   // Return an alchemy AA signer from the turnkey signer
   return {
@@ -130,3 +84,93 @@ export async function getCustodialOwner(
       turnkeySigner.signTypedData(params),
   };
 }
+
+/**
+ * Try to load sign data from a local custodial file path
+ */
+const loadSignDataFromCustodialFile = memo(async (custodialFilePath: string) => {
+    const [,fsModule] = await tryit(() => import("fs"))();
+    if (!fsModule) {
+        console.log("FS module not available. Skipping FS operation...");
+        return;
+    }
+    const data = fsModule.readFileSync(custodialFilePath, "utf8");
+    return data.split("\n");
+}, {
+    // TTL of 30sec, to avoid reading the file too often
+    ttl: 1000 * 30,
+    // The key in the cache
+    key: (custodialFilePath: string) => `${custodialFilePath}`
+});
+
+/**
+ * Get our default turnkey client
+ */
+const getDefaultTurnkeyClient = memo(async ({privateKey, publicKey}: {privateKey: string, publicKey: string}) => {
+    // Try to fetch turnkey client & api key stamper
+    const [, turnkeyHttp] = await tryit(() => import("@turnkey/http"))();
+    const [, turnkeyApiKeyStamper] = await tryit(() =>
+        import("@turnkey/api-key-stamper")
+    )();
+    if (!turnkeyHttp || !turnkeyApiKeyStamper) {
+        console.log(
+            "@turnkey/http or @turnkey/api-key-stamper module not available. Skipping FS operation..."
+        );
+        return;
+    }
+
+    // Build the turnkey client
+    return new turnkeyHttp.TurnkeyClient(
+        {
+            baseUrl: "https://api.turnkey.com",
+        },
+        new turnkeyApiKeyStamper.ApiKeyStamper({
+            apiPublicKey: publicKey,
+            apiPrivateKey: privateKey,
+        })
+    );
+}, {
+    // TTL of 1min in the memory cache
+    ttl: 1000 * 60,
+    // The key in the cache
+    key: ({privateKey, publicKey}: {privateKey: string, publicKey: string}) => `${privateKey}-${publicKey}`
+});
+
+/**
+ * Simple function used to fetch the wallet id from the API using an identifier
+ */
+const fetchWallet = memo(({identifier, keyId, apiUrl}: {identifier: string, keyId: string, apiUrl: string}) => {
+    return axios.post<any, { data: { walletId: string } }>(
+        `${apiUrl}/wallets/${identifier}`,
+        {
+        keyId,
+        }
+    );
+}, {
+  // TTL of 1 day
+  ttl: 1000 * 60 * 60 * 24,
+  // The key in the cache
+  key: ({identifier, keyId, apiUrl}: {identifier: string, keyId: string, apiUrl: string}) => `${identifier}-${keyId}-${apiUrl}`
+});
+
+/**
+ * Get a turnkey signer
+ */
+const getTurnkeySigner = memo(async ({keyId, privateKeyId, turnkeyClient}: {keyId: string, privateKeyId: string, turnkeyClient: TurnkeyClient}) => {
+    // Get the turnkey viem account
+    const [, turnkeyViem] = await tryit(() => import("@turnkey/viem"))();
+    if (!turnkeyViem) {
+        console.log("@turnkey/viem module not available. Skipping FS operation...");
+        return;
+    }
+    return turnkeyViem.createAccount({
+        client: turnkeyClient,
+        organizationId: keyId,
+        privateKeyId,
+    });
+}, {
+  // TTL of 1 day
+    ttl: 1000 * 60 * 60 * 24,
+    // The key in the cache
+    key: ({keyId, privateKeyId}: {keyId: string, privateKeyId: string, turnkeyClient: TurnkeyClient}) => `${keyId}-${privateKeyId}`
+});

--- a/packages/accounts/src/kernel-zerodev/owner/passkey/utils.ts
+++ b/packages/accounts/src/kernel-zerodev/owner/passkey/utils.ts
@@ -47,10 +47,10 @@ export const signMessageImplementation = async (
   const signedRequest = await TurnkeyApi.signSignRawPayload(
     {
       body: {
-        type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD",
+        type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
         organizationId: id,
         parameters: {
-          privateKeyId: walletId,
+          signWith: walletId,
           payload: msg,
           encoding: "PAYLOAD_ENCODING_HEXADECIMAL",
           hashFunction: "HASH_FUNCTION_NO_OP",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3922,24 +3922,24 @@
   resolved "https://registry.yarnpkg.com/@turnkey/api-key-stamper/-/api-key-stamper-0.1.1.tgz#7a5b5cd9cee7bd05059b87ccf66bfc264dbbd8a0"
   integrity sha512-qs8fmWFiAhh7fAByx7j9/2F0VRe/qD7Yq3hi4FwD+jLU0CXdE+aim1cmJpAFFPKF1PBmPs6jh4XBODE40eqEEg==
 
-"@turnkey/http@1.3.0", "@turnkey/http@^1.2.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@turnkey/http/-/http-1.3.0.tgz#c21389d0997a305888911b345fdcf44f16dd7878"
-  integrity sha512-vl/z3GSRY5ZvjHvb7gpfyq8HXj630yYViHqtstTRtGCv1QaNxgsDzZ/ECkN8fWiJJj/4SUiiKw6jSeHL0jTAew==
+"@turnkey/http@2.1.0", "@turnkey/http@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@turnkey/http/-/http-2.1.0.tgz#120c4cd7723d0483864d45448cc8d344b3cbcd52"
+  integrity sha512-v5xlSKKuTYPRG1WswPbYD/Jrb9oF6+ulscI7gO/D28S6vq/al6THMp3XYa+DxF9aoVM+UIaTmx51K/PBECbV2Q==
   dependencies:
     "@turnkey/api-key-stamper" "0.1.1"
     "@turnkey/webauthn-stamper" "0.2.0"
     cross-fetch "^3.1.5"
 
 "@turnkey/viem@^0.2.4":
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/@turnkey/viem/-/viem-0.2.5.tgz#a4059d4cd43cbb80330cb7b78330ea7a58d42db7"
-  integrity sha512-HdXI0oi/7MfEEHDtIUjjG27/WotZBVLb8NzmqKzSnyiDvBC0UX4toba6pobKngxtehg/5DznJW961d7CRAx2Gw==
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/@turnkey/viem/-/viem-0.2.7.tgz#f2670f23b45e011acca6b6cbe6eecc60bbcdadd1"
+  integrity sha512-G75Lso0ldX1XBKpTsZ/9lcGH03o04A3b4JXHg4DM8cdJb8JzgUPGyqgQg+vN/FAqE6e7QgxADkZNtx70Kdm+HA==
   dependencies:
     "@turnkey/api-key-stamper" "0.1.1"
-    "@turnkey/http" "1.3.0"
+    "@turnkey/http" "2.1.0"
     cross-fetch "^4.0.0"
-    typescript "5.1"
+    typescript "^5.1"
 
 "@turnkey/webauthn-stamper@0.2.0":
   version "0.2.0"
@@ -5990,12 +5990,19 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-fetch@^3.1.4, cross-fetch@^3.1.5:
+cross-fetch@^3.1.4:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.6.tgz#bae05aa31a4da760969756318feeee6e70f15d6c"
   integrity sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==
   dependencies:
     node-fetch "^2.6.11"
+
+cross-fetch@^3.1.5:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.8.tgz#0327eba65fd68a7d119f8fb2bf9334a1a7956f82"
+  integrity sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==
+  dependencies:
+    node-fetch "^2.6.12"
 
 cross-fetch@^4.0.0:
   version "4.0.0"
@@ -9401,17 +9408,17 @@ node-fetch@2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-fetch@^2.6.11, node-fetch@^2.6.7:
-  version "2.6.11"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.11.tgz#cde7fc71deef3131ef80a738919f999e6edfff25"
-  integrity sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==
-  dependencies:
-    whatwg-url "^5.0.0"
-
-node-fetch@^2.6.12:
+node-fetch@^2.6.11, node-fetch@^2.6.12:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.6.7:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.11.tgz#cde7fc71deef3131ef80a738919f999e6edfff25"
+  integrity sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==
   dependencies:
     whatwg-url "^5.0.0"
 
@@ -10458,6 +10465,11 @@ quick-lru@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
+
+radash@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/radash/-/radash-11.0.0.tgz#925698e94b554336fc159c253ac33a9a49881835"
+  integrity sha512-CRWxTFTDff0IELGJ/zz58yY4BDgyI14qSM5OLNKbCItJrff7m7dXbVF0kWYVCXQtPb3SXIVhXvAImH6eT7VLSg==
 
 randombytes@^2.1.0:
   version "2.1.0"
@@ -11830,11 +11842,6 @@ typescript-template@*:
   dependencies:
     sitka "^1.0.6"
 
-typescript@5.1:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
-  integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
-
 "typescript@^3 || ^4":
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
@@ -11844,6 +11851,11 @@ typescript@5.1:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.3.tgz#8d84219244a6b40b6fb2b33cc1c062f715b9e826"
   integrity sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==
+
+typescript@^5.1:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 ufo@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
- Update `@turnkey/http` to `2.1.0`
- Update `@turnkey/viem` to `0.2.7` (in lockfile only)
- Adding `radash` dependencies inside `accounts` module (used for inline try catch block and memo function for in memory cache)
- Simplify optional module import to use `tryit` from radash instead of `try {...} catch() {..}` block
- Adding 1min in memory caching  inside the method `getCustodialOwner()` on:
  - Read data from `custodialFilePath`
  - Build default `turnkeyClient` if not provided
  - Fetch the `privateKeyIdentifier` of a wallet from the api
  - Build the `turnkeySigner` for a wallet