### PR TITLE
fix: centralize test configuration in ./__tests__/config directory

### DIFF
--- a/packages/accounts/src/kernel-zerodev/__tests__/config/index.ts
+++ b/packages/accounts/src/kernel-zerodev/__tests__/config/index.ts
@@ -1,0 +1,20 @@
+import { polygonMumbai } from "viem/chains";
+import { generatePrivateKey } from "viem/accounts";
+import {
+  type Hex,
+} from "viem";
+
+export const config = {
+  privateKey: (process.env.PRIVATE_KEY as Hex) ?? generatePrivateKey(),
+  ownerWallet: process.env.OWNER_WALLET,
+  mockWallet: "0x48D4d3536cDe7A257087206870c6B6E76e3D4ff4",
+  chain: polygonMumbai,
+  rpcProvider: "https://mumbai-bundler.etherspot.io/",
+  validatorAddress: "0xd9AB5096a832b9ce79914329DAEE236f8Eea0390" as Hex,
+  accountFactoryAddress: "0x5de4839a76cf55d0c90e2061ef4386d962E15ae3" as Hex,
+  entryPointAddress: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789" as Hex,
+  // Turn off all policies related to gas sponsorship for this projectId
+  // To make all the testcases pass
+  projectId: "8db3f9f0-f8d0-4c69-9bc6-5c522ee25844",
+  projectIdWithGasSponsorship: "c73037ef-8c0b-48be-a581-1f3d161151d3",
+};

--- a/packages/accounts/src/kernel-zerodev/__tests__/kernel-account.test.ts
+++ b/packages/accounts/src/kernel-zerodev/__tests__/kernel-account.test.ts
@@ -8,26 +8,11 @@ import {
   http,
 } from "viem";
 import { polygonMumbai } from "viem/chains";
-import { generatePrivateKey } from "viem/accounts";
 import { LocalAccountSigner } from "@alchemy/aa-core";
 import { TEST_ERC20Abi } from "../abis/Test_ERC20Abi.js";
 import { ECDSAProvider } from "../validator-provider/index.js";
 import { CHAIN_ID_TO_NODE } from "../constants.js";
-
-export const config = {
-  privateKey: (process.env.PRIVATE_KEY as Hex) ?? generatePrivateKey(),
-  ownerWallet: process.env.OWNER_WALLET,
-  mockWallet: "0x48D4d3536cDe7A257087206870c6B6E76e3D4ff4",
-  chain: polygonMumbai,
-  rpcProvider: "https://mumbai-bundler.etherspot.io/",
-  validatorAddress: "0xd9AB5096a832b9ce79914329DAEE236f8Eea0390" as Hex,
-  accountFactoryAddress: "0x5de4839a76cf55d0c90e2061ef4386d962E15ae3" as Hex,
-  entryPointAddress: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789" as Hex,
-  // Turn off all policies related to gas sponsorship for this projectId
-  // To make all the testcases pass
-  projectId: "8db3f9f0-f8d0-4c69-9bc6-5c522ee25844",
-  projectIdWithGasSponsorship: "c73037ef-8c0b-48be-a581-1f3d161151d3",
-};
+import { config } from "./config/index.js";
 
 // [TODO] - Organize instantiations and tests properly
 

--- a/packages/accounts/src/kernel-zerodev/__tests__/kernel-ecdsa-ethers-provider.test.ts
+++ b/packages/accounts/src/kernel-zerodev/__tests__/kernel-ecdsa-ethers-provider.test.ts
@@ -1,6 +1,6 @@
 import { Wallet } from "@ethersproject/wallet";
 import { ZeroDevEthersProvider } from "../ethers-provider/ethers-provider.js";
-import { config } from "./kernel-account.test.js";
+import { config } from "./config/index.js";
 import { convertEthersSignerToAccountSigner } from "../utils.js";
 import { type TypedDataDomain, recoverTypedDataAddress, type Hex } from "viem";
 

--- a/packages/accounts/src/kernel-zerodev/__tests__/kernel-ecdsa-validator.test.ts
+++ b/packages/accounts/src/kernel-zerodev/__tests__/kernel-ecdsa-validator.test.ts
@@ -1,6 +1,6 @@
 import { ECDSAValidator } from "../validator/ecdsa-validator.js";
 import { LocalAccountSigner } from "@alchemy/aa-core";
-import { config } from "./kernel-account.test.js";
+import { config } from "./config/index.js";
 import type { PrivateKeyAccount } from "viem";
 import { ECDSA_VALIDATOR_ADDRESS } from "../constants.js";
 

--- a/packages/accounts/src/kernel-zerodev/__tests__/kernel-erc165-session-key-provider.test.ts
+++ b/packages/accounts/src/kernel-zerodev/__tests__/kernel-erc165-session-key-provider.test.ts
@@ -9,7 +9,7 @@ import {
 } from "viem";
 import { polygonMumbai } from "viem/chains";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
-import { config } from "./kernel-account.test.js";
+import { config } from "./config/index.js";
 import { ECDSAProvider } from "../validator-provider/index.js";
 import { CHAIN_ID_TO_NODE, TOKEN_ACTION } from "../constants.js";
 import { ValidatorMode } from "../validator/base.js";

--- a/packages/accounts/src/kernel-zerodev/__tests__/kernel-kill-switch-provider.test.ts
+++ b/packages/accounts/src/kernel-zerodev/__tests__/kernel-kill-switch-provider.test.ts
@@ -6,7 +6,7 @@ import {
   type Hash,
 } from "viem";
 import { polygonMumbai } from "viem/chains";
-import { config } from "./kernel-account.test.js";
+import { config } from "./config/index.js";
 import {
   ECDSAProvider,
   KillSwitchProvider,

--- a/packages/accounts/src/kernel-zerodev/__tests__/kernel-recovery-provider.test.ts
+++ b/packages/accounts/src/kernel-zerodev/__tests__/kernel-recovery-provider.test.ts
@@ -7,7 +7,7 @@ import {
   type LocalAccount,
 } from "viem";
 import { polygonMumbai } from "viem/chains";
-import { config } from "./kernel-account.test.js";
+import { config } from "./config/index.js";
 import {
   ECDSAProvider,
   RecoveryProvider,

--- a/packages/accounts/src/kernel-zerodev/__tests__/kernel-session-key-provider.test.ts
+++ b/packages/accounts/src/kernel-zerodev/__tests__/kernel-session-key-provider.test.ts
@@ -11,7 +11,7 @@ import {
 } from "viem";
 import { polygonMumbai } from "viem/chains";
 import { generatePrivateKey } from "viem/accounts";
-import { config } from "./kernel-account.test.js";
+import { config } from "./config/index.js";
 import { ECDSAProvider } from "../validator-provider/index.js";
 import {
   CHAIN_ID_TO_NODE,

--- a/packages/accounts/src/kernel-zerodev/__tests__/kernel-validator-provider.test.ts
+++ b/packages/accounts/src/kernel-zerodev/__tests__/kernel-validator-provider.test.ts
@@ -1,7 +1,7 @@
 import { createPublicClient, http, type Hex } from "viem";
 import { polygonMumbai } from "viem/chains";
 import { ECDSAValidatorAbi } from "../abis/ESCDAValidatorAbi.js";
-import { config } from "./kernel-account.test.js";
+import { config } from "./config/index.js";
 import { LocalAccountSigner } from "@alchemy/aa-core";
 import { generatePrivateKey } from "viem/accounts";
 import { ECDSAProvider } from "../validator-provider/index.js";


### PR DESCRIPTION
### Summary of Changes

- **`./__tests__/config/index.js`**: Introduced this new file as a centralized source for common test configurations previously defined in **`kernel-account.test.ts`** and imported into all other test files.
- **`kernel-account.test.ts`**: Extracted the shared configuration object and updated to import it from the new `./__tests__/config/index.js`
- **All other test files**: Refactored to import the centralized test configuration from `./__tests__/config/index.js` instead of from **`kernel-account.test.ts`**, fixing bug of repeating **`kernel-account.test.ts`** tests between all other tests