### PR TITLE
Do not fetch chain ID until it's actually needed

### DIFF
--- a/plugins/multi-chain-weighted-validator/signers/toWebAuthnSigner.ts
+++ b/plugins/multi-chain-weighted-validator/signers/toWebAuthnSigner.ts
@@ -130,12 +130,11 @@ export const toWebAuthnSigner = async <
     client: Client<TTransport, TChain, undefined>,
     { webAuthnKey }: WebAuthnModularSignerParams
 ): Promise<WeightedSigner> => {
-    const chainId = await getChainId(client)
-
     const account: LocalAccount = toAccount({
         // note that this address will be overwritten by actual address
         address: "0x0000000000000000000000000000000000000000",
         async signMessage({ message }) {
+            const chainId = await getChainId(client)
             return signMessageUsingWebAuthn(message, chainId, [
                 { id: webAuthnKey.authenticatorId, type: "public-key" }
             ])


### PR DESCRIPTION
The `chainId` is not really needed unless we want to call `signMessage`.

In a multi chain weighted validator scenario, `signedMessage` is only called by the last signer.

Without this change, for each chain we want to sign for, we have to make an unnecessary call to the bundler to get a chain ID we will never use.