### PR TITLE
Make passkeys server request headers more flexible

### DIFF
--- a/plugins/modularPermission/signers/toWebAuthnPubKey.ts
+++ b/plugins/modularPermission/signers/toWebAuthnPubKey.ts
@@ -9,11 +9,13 @@ export enum WebAuthnMode {
 export const toWebAuthnPubKey = async ({
     passkeyName,
     passkeyServerUrl,
-    mode = WebAuthnMode.Login
+    mode = WebAuthnMode.Login,
+    headers = { "Content-Type": "application/json" },
 }: {
     passkeyName: string
     passkeyServerUrl: string
     mode: WebAuthnMode
+    headers?: Record<string, string>
 }): Promise<WebAuthnKey> => {
     let pubKey: string | undefined
     if (mode === WebAuthnMode.Login) {
@@ -22,7 +24,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/login/options`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json" },
+                headers,
                 credentials: "include"
             }
         )
@@ -37,7 +39,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/login/verify`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json" },
+                headers,
                 body: JSON.stringify({ cred: loginCred }),
                 credentials: "include"
             }
@@ -64,9 +66,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/register/options`,
             {
                 method: "POST",
-                headers: {
-                    "Content-Type": "application/json"
-                },
+                headers,
                 body: JSON.stringify({ username: passkeyName }),
                 credentials: "include"
             }
@@ -88,9 +88,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/register/verify`,
             {
                 method: "POST",
-                headers: {
-                    "Content-Type": "application/json"
-                },
+                headers,
                 body: JSON.stringify({
                     userId: registerOptions.userId,
                     username: passkeyName,

--- a/plugins/modularPermission/signers/toWebAuthnPubKey.ts
+++ b/plugins/modularPermission/signers/toWebAuthnPubKey.ts
@@ -10,12 +10,12 @@ export const toWebAuthnPubKey = async ({
     passkeyName,
     passkeyServerUrl,
     mode = WebAuthnMode.Login,
-    headers = {}
+    passkeyServerHeaders = {}
 }: {
     passkeyName: string
     passkeyServerUrl: string
     mode: WebAuthnMode
-    headers: Record<string, string>
+    passkeyServerHeaders: Record<string, string>
 }): Promise<WebAuthnKey> => {
     let pubKey: string | undefined
     if (mode === WebAuthnMode.Login) {
@@ -24,7 +24,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/login/options`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...headers },
+                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
                 credentials: "include"
             }
         )
@@ -39,7 +39,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/login/verify`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...headers },
+                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
                 body: JSON.stringify({ cred: loginCred }),
                 credentials: "include"
             }
@@ -66,7 +66,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/register/options`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...headers },
+                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
                 body: JSON.stringify({ username: passkeyName }),
                 credentials: "include"
             }
@@ -88,7 +88,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/register/verify`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...headers },
+                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
                 body: JSON.stringify({
                     userId: registerOptions.userId,
                     username: passkeyName,

--- a/plugins/modularPermission/signers/toWebAuthnPubKey.ts
+++ b/plugins/modularPermission/signers/toWebAuthnPubKey.ts
@@ -10,7 +10,7 @@ export const toWebAuthnPubKey = async ({
     passkeyName,
     passkeyServerUrl,
     mode = WebAuthnMode.Login,
-    headers = { "Content-Type": "application/json" }
+    headers = {}
 }: {
     passkeyName: string
     passkeyServerUrl: string
@@ -24,7 +24,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/login/options`,
             {
                 method: "POST",
-                headers,
+                headers: { "Content-Type": "application/json", ...headers },
                 credentials: "include"
             }
         )
@@ -39,7 +39,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/login/verify`,
             {
                 method: "POST",
-                headers,
+                headers: { "Content-Type": "application/json", ...headers },
                 body: JSON.stringify({ cred: loginCred }),
                 credentials: "include"
             }
@@ -66,7 +66,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/register/options`,
             {
                 method: "POST",
-                headers,
+                headers: { "Content-Type": "application/json", ...headers },
                 body: JSON.stringify({ username: passkeyName }),
                 credentials: "include"
             }
@@ -88,7 +88,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/register/verify`,
             {
                 method: "POST",
-                headers,
+                headers: { "Content-Type": "application/json", ...headers },
                 body: JSON.stringify({
                     userId: registerOptions.userId,
                     username: passkeyName,

--- a/plugins/modularPermission/signers/toWebAuthnPubKey.ts
+++ b/plugins/modularPermission/signers/toWebAuthnPubKey.ts
@@ -24,7 +24,10 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/login/options`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: {
+                    "Content-Type": "application/json",
+                    ...passkeyServerHeaders
+                },
                 credentials: "include"
             }
         )
@@ -39,7 +42,10 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/login/verify`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: {
+                    "Content-Type": "application/json",
+                    ...passkeyServerHeaders
+                },
                 body: JSON.stringify({ cred: loginCred }),
                 credentials: "include"
             }
@@ -66,7 +72,10 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/register/options`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: {
+                    "Content-Type": "application/json",
+                    ...passkeyServerHeaders
+                },
                 body: JSON.stringify({ username: passkeyName }),
                 credentials: "include"
             }
@@ -88,7 +97,10 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/register/verify`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: {
+                    "Content-Type": "application/json",
+                    ...passkeyServerHeaders
+                },
                 body: JSON.stringify({
                     userId: registerOptions.userId,
                     username: passkeyName,

--- a/plugins/modularPermission/signers/toWebAuthnPubKey.ts
+++ b/plugins/modularPermission/signers/toWebAuthnPubKey.ts
@@ -10,12 +10,12 @@ export const toWebAuthnPubKey = async ({
     passkeyName,
     passkeyServerUrl,
     mode = WebAuthnMode.Login,
-    passkeyServerHeaders = {}
+    headers = {}
 }: {
     passkeyName: string
     passkeyServerUrl: string
     mode: WebAuthnMode
-    passkeyServerHeaders: Record<string, string>
+    headers: Record<string, string>
 }): Promise<WebAuthnKey> => {
     let pubKey: string | undefined
     if (mode === WebAuthnMode.Login) {
@@ -24,7 +24,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/login/options`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: { "Content-Type": "application/json", ...headers },
                 credentials: "include"
             }
         )
@@ -39,7 +39,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/login/verify`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: { "Content-Type": "application/json", ...headers },
                 body: JSON.stringify({ cred: loginCred }),
                 credentials: "include"
             }
@@ -66,7 +66,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/register/options`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: { "Content-Type": "application/json", ...headers },
                 body: JSON.stringify({ username: passkeyName }),
                 credentials: "include"
             }
@@ -88,7 +88,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/register/verify`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: { "Content-Type": "application/json", ...headers },
                 body: JSON.stringify({
                     userId: registerOptions.userId,
                     username: passkeyName,

--- a/plugins/modularPermission/signers/toWebAuthnPubKey.ts
+++ b/plugins/modularPermission/signers/toWebAuthnPubKey.ts
@@ -10,7 +10,7 @@ export const toWebAuthnPubKey = async ({
     passkeyName,
     passkeyServerUrl,
     mode = WebAuthnMode.Login,
-    headers = { "Content-Type": "application/json" },
+    headers = { "Content-Type": "application/json" }
 }: {
     passkeyName: string
     passkeyServerUrl: string

--- a/plugins/modularPermission/signers/toWebAuthnPubKey.ts
+++ b/plugins/modularPermission/signers/toWebAuthnPubKey.ts
@@ -15,7 +15,7 @@ export const toWebAuthnPubKey = async ({
     passkeyName: string
     passkeyServerUrl: string
     mode: WebAuthnMode
-    headers?: Record<string, string>
+    headers: Record<string, string>
 }): Promise<WebAuthnKey> => {
     let pubKey: string | undefined
     if (mode === WebAuthnMode.Login) {

--- a/plugins/modularPermission/signers/toWebAuthnSigner.ts
+++ b/plugins/modularPermission/signers/toWebAuthnSigner.ts
@@ -36,7 +36,7 @@ export type WebAuthnModularSignerParams = ModularSignerParams & {
     passkeyServerUrl: string
     pubKey?: WebAuthnKey
     mode?: WebAuthnMode
-    passkeyServerHeaders: Record<string, string>
+    headers: Record<string, string>
 }
 
 export const toWebAuthnSigner = async <
@@ -50,7 +50,7 @@ export const toWebAuthnSigner = async <
         passkeyServerUrl,
         passkeyName,
         mode = WebAuthnMode.Register,
-        passkeyServerHeaders = {}
+        headers = {}
     }: WebAuthnModularSignerParams
 ): Promise<ModularSigner> => {
     pubKey =
@@ -59,7 +59,7 @@ export const toWebAuthnSigner = async <
             passkeyName,
             passkeyServerUrl,
             mode,
-            passkeyServerHeaders
+            headers
         }))
     if (!pubKey) {
         throw new Error("WebAuthn public key not found")
@@ -97,7 +97,7 @@ export const toWebAuthnSigner = async <
             `${passkeyServerUrl}/sign-initiate`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: { "Content-Type": "application/json", ...headers },
                 body: JSON.stringify({ data: formattedMessage, userId }),
                 credentials: "include"
             }
@@ -118,7 +118,7 @@ export const toWebAuthnSigner = async <
         // verify signature from server
         const verifyResponse = await fetch(`${passkeyServerUrl}/sign-verify`, {
             method: "POST",
-            headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+            headers: { "Content-Type": "application/json", ...headers },
             body: JSON.stringify({ cred, userId }),
             credentials: "include"
         })

--- a/plugins/modularPermission/signers/toWebAuthnSigner.ts
+++ b/plugins/modularPermission/signers/toWebAuthnSigner.ts
@@ -97,7 +97,10 @@ export const toWebAuthnSigner = async <
             `${passkeyServerUrl}/sign-initiate`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: {
+                    "Content-Type": "application/json",
+                    ...passkeyServerHeaders
+                },
                 body: JSON.stringify({ data: formattedMessage, userId }),
                 credentials: "include"
             }
@@ -118,7 +121,10 @@ export const toWebAuthnSigner = async <
         // verify signature from server
         const verifyResponse = await fetch(`${passkeyServerUrl}/sign-verify`, {
             method: "POST",
-            headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+            headers: {
+                "Content-Type": "application/json",
+                ...passkeyServerHeaders
+            },
             body: JSON.stringify({ cred, userId }),
             credentials: "include"
         })

--- a/plugins/modularPermission/signers/toWebAuthnSigner.ts
+++ b/plugins/modularPermission/signers/toWebAuthnSigner.ts
@@ -36,7 +36,7 @@ export type WebAuthnModularSignerParams = ModularSignerParams & {
     passkeyServerUrl: string
     pubKey?: WebAuthnKey
     mode?: WebAuthnMode
-    headers: Record<string, string>
+    passkeyServerHeaders: Record<string, string>
 }
 
 export const toWebAuthnSigner = async <
@@ -50,7 +50,7 @@ export const toWebAuthnSigner = async <
         passkeyServerUrl,
         passkeyName,
         mode = WebAuthnMode.Register,
-        headers = {}
+        passkeyServerHeaders = {}
     }: WebAuthnModularSignerParams
 ): Promise<ModularSigner> => {
     pubKey =
@@ -59,7 +59,7 @@ export const toWebAuthnSigner = async <
             passkeyName,
             passkeyServerUrl,
             mode,
-            headers
+            passkeyServerHeaders
         }))
     if (!pubKey) {
         throw new Error("WebAuthn public key not found")
@@ -97,7 +97,7 @@ export const toWebAuthnSigner = async <
             `${passkeyServerUrl}/sign-initiate`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...headers },
+                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
                 body: JSON.stringify({ data: formattedMessage, userId }),
                 credentials: "include"
             }
@@ -118,7 +118,7 @@ export const toWebAuthnSigner = async <
         // verify signature from server
         const verifyResponse = await fetch(`${passkeyServerUrl}/sign-verify`, {
             method: "POST",
-            headers: { "Content-Type": "application/json", ...headers },
+            headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
             body: JSON.stringify({ cred, userId }),
             credentials: "include"
         })

--- a/plugins/modularPermission/signers/toWebAuthnSigner.ts
+++ b/plugins/modularPermission/signers/toWebAuthnSigner.ts
@@ -36,7 +36,7 @@ export type WebAuthnModularSignerParams = ModularSignerParams & {
     passkeyServerUrl: string
     pubKey?: WebAuthnKey
     mode?: WebAuthnMode
-    headers?: Record<string, string>
+    headers: Record<string, string>
 }
 
 export const toWebAuthnSigner = async <

--- a/plugins/modularPermission/signers/toWebAuthnSigner.ts
+++ b/plugins/modularPermission/signers/toWebAuthnSigner.ts
@@ -36,6 +36,7 @@ export type WebAuthnModularSignerParams = ModularSignerParams & {
     passkeyServerUrl: string
     pubKey?: WebAuthnKey
     mode?: WebAuthnMode
+    headers?: Record<string, string>
 }
 
 export const toWebAuthnSigner = async <
@@ -48,7 +49,8 @@ export const toWebAuthnSigner = async <
         pubKey,
         passkeyServerUrl,
         passkeyName,
-        mode = WebAuthnMode.Register
+        mode = WebAuthnMode.Register,
+        headers = { "Content-Type": "application/json" }
     }: WebAuthnModularSignerParams
 ): Promise<ModularSigner> => {
     pubKey =
@@ -56,7 +58,8 @@ export const toWebAuthnSigner = async <
         (await toWebAuthnPubKey({
             passkeyName,
             passkeyServerUrl,
-            mode
+            mode,
+            headers
         }))
     if (!pubKey) {
         throw new Error("WebAuthn public key not found")
@@ -94,7 +97,7 @@ export const toWebAuthnSigner = async <
             `${passkeyServerUrl}/sign-initiate`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json" },
+                headers,
                 body: JSON.stringify({ data: formattedMessage, userId }),
                 credentials: "include"
             }
@@ -115,7 +118,7 @@ export const toWebAuthnSigner = async <
         // verify signature from server
         const verifyResponse = await fetch(`${passkeyServerUrl}/sign-verify`, {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
+            headers,
             body: JSON.stringify({ cred, userId }),
             credentials: "include"
         })

--- a/plugins/modularPermission/signers/toWebAuthnSigner.ts
+++ b/plugins/modularPermission/signers/toWebAuthnSigner.ts
@@ -50,7 +50,7 @@ export const toWebAuthnSigner = async <
         passkeyServerUrl,
         passkeyName,
         mode = WebAuthnMode.Register,
-        headers = { "Content-Type": "application/json" }
+        headers = {}
     }: WebAuthnModularSignerParams
 ): Promise<ModularSigner> => {
     pubKey =
@@ -97,7 +97,7 @@ export const toWebAuthnSigner = async <
             `${passkeyServerUrl}/sign-initiate`,
             {
                 method: "POST",
-                headers,
+                headers: { "Content-Type": "application/json", ...headers },
                 body: JSON.stringify({ data: formattedMessage, userId }),
                 credentials: "include"
             }
@@ -118,7 +118,7 @@ export const toWebAuthnSigner = async <
         // verify signature from server
         const verifyResponse = await fetch(`${passkeyServerUrl}/sign-verify`, {
             method: "POST",
-            headers,
+            headers: { "Content-Type": "application/json", ...headers },
             body: JSON.stringify({ cred, userId }),
             credentials: "include"
         })

--- a/plugins/webauthn-key/toWebAuthnKey.ts
+++ b/plugins/webauthn-key/toWebAuthnKey.ts
@@ -19,7 +19,7 @@ export type WebAuthnAccountParams = {
     webAuthnKey?: WebAuthnKey
     mode?: WebAuthnMode
     credentials?: RequestCredentials
-    headers?: Record<string, string>
+    headers: Record<string, string>
 }
 
 export const encodeWebAuthnPubKey = (pubKey: WebAuthnKey) => {

--- a/plugins/webauthn-key/toWebAuthnKey.ts
+++ b/plugins/webauthn-key/toWebAuthnKey.ts
@@ -19,6 +19,7 @@ export type WebAuthnAccountParams = {
     webAuthnKey?: WebAuthnKey
     mode?: WebAuthnMode
     credentials?: RequestCredentials
+    headers?: Record<string, string>
 }
 
 export const encodeWebAuthnPubKey = (pubKey: WebAuthnKey) => {
@@ -34,7 +35,8 @@ export const toWebAuthnKey = async ({
     passkeyServerUrl,
     webAuthnKey,
     mode = WebAuthnMode.Register,
-    credentials = "include"
+    credentials = "include",
+    headers = { "Content-Type": "application/json" }
 }: WebAuthnAccountParams): Promise<WebAuthnKey> => {
     if (webAuthnKey) {
         return webAuthnKey
@@ -47,7 +49,7 @@ export const toWebAuthnKey = async ({
             `${passkeyServerUrl}/login/options`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json" },
+                headers,
                 credentials
             }
         )
@@ -64,7 +66,7 @@ export const toWebAuthnKey = async ({
             `${passkeyServerUrl}/login/verify`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json" },
+                headers,
                 body: JSON.stringify({ cred: loginCred }),
                 credentials
             }
@@ -83,9 +85,7 @@ export const toWebAuthnKey = async ({
             `${passkeyServerUrl}/register/options`,
             {
                 method: "POST",
-                headers: {
-                    "Content-Type": "application/json"
-                },
+                headers,
                 body: JSON.stringify({ username: passkeyName }),
                 credentials
             }
@@ -103,9 +103,7 @@ export const toWebAuthnKey = async ({
             `${passkeyServerUrl}/register/verify`,
             {
                 method: "POST",
-                headers: {
-                    "Content-Type": "application/json"
-                },
+                headers,
                 body: JSON.stringify({
                     userId: registerOptions.userId,
                     username: passkeyName,

--- a/plugins/webauthn-key/toWebAuthnKey.ts
+++ b/plugins/webauthn-key/toWebAuthnKey.ts
@@ -49,7 +49,10 @@ export const toWebAuthnKey = async ({
             `${passkeyServerUrl}/login/options`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: {
+                    "Content-Type": "application/json",
+                    ...passkeyServerHeaders
+                },
                 credentials
             }
         )
@@ -66,7 +69,10 @@ export const toWebAuthnKey = async ({
             `${passkeyServerUrl}/login/verify`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: {
+                    "Content-Type": "application/json",
+                    ...passkeyServerHeaders
+                },
                 body: JSON.stringify({ cred: loginCred }),
                 credentials
             }
@@ -85,7 +91,10 @@ export const toWebAuthnKey = async ({
             `${passkeyServerUrl}/register/options`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: {
+                    "Content-Type": "application/json",
+                    ...passkeyServerHeaders
+                },
                 body: JSON.stringify({ username: passkeyName }),
                 credentials
             }
@@ -103,7 +112,10 @@ export const toWebAuthnKey = async ({
             `${passkeyServerUrl}/register/verify`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: {
+                    "Content-Type": "application/json",
+                    ...passkeyServerHeaders
+                },
                 body: JSON.stringify({
                     userId: registerOptions.userId,
                     username: passkeyName,

--- a/plugins/webauthn-key/toWebAuthnKey.ts
+++ b/plugins/webauthn-key/toWebAuthnKey.ts
@@ -36,7 +36,7 @@ export const toWebAuthnKey = async ({
     webAuthnKey,
     mode = WebAuthnMode.Register,
     credentials = "include",
-    headers = { "Content-Type": "application/json" }
+    headers = {}
 }: WebAuthnAccountParams): Promise<WebAuthnKey> => {
     if (webAuthnKey) {
         return webAuthnKey
@@ -49,7 +49,7 @@ export const toWebAuthnKey = async ({
             `${passkeyServerUrl}/login/options`,
             {
                 method: "POST",
-                headers,
+                headers: { "Content-Type": "application/json", ...headers },
                 credentials
             }
         )
@@ -66,7 +66,7 @@ export const toWebAuthnKey = async ({
             `${passkeyServerUrl}/login/verify`,
             {
                 method: "POST",
-                headers,
+                headers: { "Content-Type": "application/json", ...headers },
                 body: JSON.stringify({ cred: loginCred }),
                 credentials
             }
@@ -85,7 +85,7 @@ export const toWebAuthnKey = async ({
             `${passkeyServerUrl}/register/options`,
             {
                 method: "POST",
-                headers,
+                headers: { "Content-Type": "application/json", ...headers },
                 body: JSON.stringify({ username: passkeyName }),
                 credentials
             }
@@ -103,7 +103,7 @@ export const toWebAuthnKey = async ({
             `${passkeyServerUrl}/register/verify`,
             {
                 method: "POST",
-                headers,
+                headers: { "Content-Type": "application/json", ...headers },
                 body: JSON.stringify({
                     userId: registerOptions.userId,
                     username: passkeyName,

--- a/plugins/webauthn-key/toWebAuthnKey.ts
+++ b/plugins/webauthn-key/toWebAuthnKey.ts
@@ -19,7 +19,7 @@ export type WebAuthnAccountParams = {
     webAuthnKey?: WebAuthnKey
     mode?: WebAuthnMode
     credentials?: RequestCredentials
-    headers: Record<string, string>
+    passkeyServerHeaders: Record<string, string>
 }
 
 export const encodeWebAuthnPubKey = (pubKey: WebAuthnKey) => {
@@ -36,7 +36,7 @@ export const toWebAuthnKey = async ({
     webAuthnKey,
     mode = WebAuthnMode.Register,
     credentials = "include",
-    headers = {}
+    passkeyServerHeaders = {}
 }: WebAuthnAccountParams): Promise<WebAuthnKey> => {
     if (webAuthnKey) {
         return webAuthnKey
@@ -49,7 +49,7 @@ export const toWebAuthnKey = async ({
             `${passkeyServerUrl}/login/options`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...headers },
+                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
                 credentials
             }
         )
@@ -66,7 +66,7 @@ export const toWebAuthnKey = async ({
             `${passkeyServerUrl}/login/verify`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...headers },
+                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
                 body: JSON.stringify({ cred: loginCred }),
                 credentials
             }
@@ -85,7 +85,7 @@ export const toWebAuthnKey = async ({
             `${passkeyServerUrl}/register/options`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...headers },
+                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
                 body: JSON.stringify({ username: passkeyName }),
                 credentials
             }
@@ -103,7 +103,7 @@ export const toWebAuthnKey = async ({
             `${passkeyServerUrl}/register/verify`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...headers },
+                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
                 body: JSON.stringify({
                     userId: registerOptions.userId,
                     username: passkeyName,

--- a/plugins/webauthn-key/toWebAuthnKey.ts
+++ b/plugins/webauthn-key/toWebAuthnKey.ts
@@ -19,7 +19,7 @@ export type WebAuthnAccountParams = {
     webAuthnKey?: WebAuthnKey
     mode?: WebAuthnMode
     credentials?: RequestCredentials
-    passkeyServerHeaders: Record<string, string>
+    headers: Record<string, string>
 }
 
 export const encodeWebAuthnPubKey = (pubKey: WebAuthnKey) => {
@@ -36,7 +36,7 @@ export const toWebAuthnKey = async ({
     webAuthnKey,
     mode = WebAuthnMode.Register,
     credentials = "include",
-    passkeyServerHeaders = {}
+    headers = {}
 }: WebAuthnAccountParams): Promise<WebAuthnKey> => {
     if (webAuthnKey) {
         return webAuthnKey
@@ -49,7 +49,7 @@ export const toWebAuthnKey = async ({
             `${passkeyServerUrl}/login/options`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: { "Content-Type": "application/json", ...headers },
                 credentials
             }
         )
@@ -66,7 +66,7 @@ export const toWebAuthnKey = async ({
             `${passkeyServerUrl}/login/verify`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: { "Content-Type": "application/json", ...headers },
                 body: JSON.stringify({ cred: loginCred }),
                 credentials
             }
@@ -85,7 +85,7 @@ export const toWebAuthnKey = async ({
             `${passkeyServerUrl}/register/options`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: { "Content-Type": "application/json", ...headers },
                 body: JSON.stringify({ username: passkeyName }),
                 credentials
             }
@@ -103,7 +103,7 @@ export const toWebAuthnKey = async ({
             `${passkeyServerUrl}/register/verify`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: { "Content-Type": "application/json", ...headers },
                 body: JSON.stringify({
                     userId: registerOptions.userId,
                     username: passkeyName,

--- a/plugins/weighted-r1-k1/signers/toWebAuthnPubKey.ts
+++ b/plugins/weighted-r1-k1/signers/toWebAuthnPubKey.ts
@@ -12,7 +12,7 @@ export const toWebAuthnPubKey = async ({
     passkeyName,
     passkeyServerUrl,
     mode = WebAuthnMode.Login,
-    headers = { "Content-Type": "application/json" }
+    headers = {}
 }: {
     passkeyName: string
     passkeyServerUrl: string
@@ -27,7 +27,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/login/options`,
             {
                 method: "POST",
-                headers,
+                headers: { "Content-Type": "application/json", ...headers },
                 credentials: "include"
             }
         )
@@ -47,7 +47,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/login/verify`,
             {
                 method: "POST",
-                headers,
+                headers: { "Content-Type": "application/json", ...headers },
                 body: JSON.stringify({ cred: loginCred }),
                 credentials: "include"
             }
@@ -74,7 +74,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/register/options`,
             {
                 method: "POST",
-                headers,
+                headers: { "Content-Type": "application/json", ...headers },
                 body: JSON.stringify({ username: passkeyName }),
                 credentials: "include"
             }
@@ -101,7 +101,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/register/verify`,
             {
                 method: "POST",
-                headers,
+                headers: { "Content-Type": "application/json", ...headers },
                 body: JSON.stringify({
                     userId: registerOptions.userId,
                     username: passkeyName,

--- a/plugins/weighted-r1-k1/signers/toWebAuthnPubKey.ts
+++ b/plugins/weighted-r1-k1/signers/toWebAuthnPubKey.ts
@@ -27,7 +27,10 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/login/options`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: {
+                    "Content-Type": "application/json",
+                    ...passkeyServerHeaders
+                },
                 credentials: "include"
             }
         )
@@ -47,7 +50,10 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/login/verify`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: {
+                    "Content-Type": "application/json",
+                    ...passkeyServerHeaders
+                },
                 body: JSON.stringify({ cred: loginCred }),
                 credentials: "include"
             }
@@ -74,7 +80,10 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/register/options`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: {
+                    "Content-Type": "application/json",
+                    ...passkeyServerHeaders
+                },
                 body: JSON.stringify({ username: passkeyName }),
                 credentials: "include"
             }
@@ -101,7 +110,10 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/register/verify`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: {
+                    "Content-Type": "application/json",
+                    ...passkeyServerHeaders
+                },
                 body: JSON.stringify({
                     userId: registerOptions.userId,
                     username: passkeyName,

--- a/plugins/weighted-r1-k1/signers/toWebAuthnPubKey.ts
+++ b/plugins/weighted-r1-k1/signers/toWebAuthnPubKey.ts
@@ -11,11 +11,13 @@ export enum WebAuthnMode {
 export const toWebAuthnPubKey = async ({
     passkeyName,
     passkeyServerUrl,
-    mode = WebAuthnMode.Login
+    mode = WebAuthnMode.Login,
+    headers = { "Content-Type": "application/json" }
 }: {
     passkeyName: string
     passkeyServerUrl: string
     mode: WebAuthnMode
+    headers?: Record<string, string>
 }): Promise<WebAuthnKey> => {
     let pubKey: string | undefined
     let authenticatorIdHash: Hex
@@ -25,7 +27,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/login/options`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json" },
+                headers,
                 credentials: "include"
             }
         )
@@ -45,7 +47,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/login/verify`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json" },
+                headers,
                 body: JSON.stringify({ cred: loginCred }),
                 credentials: "include"
             }
@@ -72,9 +74,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/register/options`,
             {
                 method: "POST",
-                headers: {
-                    "Content-Type": "application/json"
-                },
+                headers,
                 body: JSON.stringify({ username: passkeyName }),
                 credentials: "include"
             }
@@ -101,9 +101,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/register/verify`,
             {
                 method: "POST",
-                headers: {
-                    "Content-Type": "application/json"
-                },
+                headers,
                 body: JSON.stringify({
                     userId: registerOptions.userId,
                     username: passkeyName,

--- a/plugins/weighted-r1-k1/signers/toWebAuthnPubKey.ts
+++ b/plugins/weighted-r1-k1/signers/toWebAuthnPubKey.ts
@@ -12,12 +12,12 @@ export const toWebAuthnPubKey = async ({
     passkeyName,
     passkeyServerUrl,
     mode = WebAuthnMode.Login,
-    passkeyServerHeaders = {}
+    headers = {}
 }: {
     passkeyName: string
     passkeyServerUrl: string
     mode: WebAuthnMode
-    passkeyServerHeaders: Record<string, string>
+    headers: Record<string, string>
 }): Promise<WebAuthnKey> => {
     let pubKey: string | undefined
     let authenticatorIdHash: Hex
@@ -27,7 +27,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/login/options`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: { "Content-Type": "application/json", ...headers },
                 credentials: "include"
             }
         )
@@ -47,7 +47,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/login/verify`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: { "Content-Type": "application/json", ...headers },
                 body: JSON.stringify({ cred: loginCred }),
                 credentials: "include"
             }
@@ -74,7 +74,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/register/options`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: { "Content-Type": "application/json", ...headers },
                 body: JSON.stringify({ username: passkeyName }),
                 credentials: "include"
             }
@@ -101,7 +101,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/register/verify`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: { "Content-Type": "application/json", ...headers },
                 body: JSON.stringify({
                     userId: registerOptions.userId,
                     username: passkeyName,

--- a/plugins/weighted-r1-k1/signers/toWebAuthnPubKey.ts
+++ b/plugins/weighted-r1-k1/signers/toWebAuthnPubKey.ts
@@ -17,7 +17,7 @@ export const toWebAuthnPubKey = async ({
     passkeyName: string
     passkeyServerUrl: string
     mode: WebAuthnMode
-    headers?: Record<string, string>
+    headers: Record<string, string>
 }): Promise<WebAuthnKey> => {
     let pubKey: string | undefined
     let authenticatorIdHash: Hex

--- a/plugins/weighted-r1-k1/signers/toWebAuthnPubKey.ts
+++ b/plugins/weighted-r1-k1/signers/toWebAuthnPubKey.ts
@@ -12,12 +12,12 @@ export const toWebAuthnPubKey = async ({
     passkeyName,
     passkeyServerUrl,
     mode = WebAuthnMode.Login,
-    headers = {}
+    passkeyServerHeaders = {}
 }: {
     passkeyName: string
     passkeyServerUrl: string
     mode: WebAuthnMode
-    headers: Record<string, string>
+    passkeyServerHeaders: Record<string, string>
 }): Promise<WebAuthnKey> => {
     let pubKey: string | undefined
     let authenticatorIdHash: Hex
@@ -27,7 +27,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/login/options`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...headers },
+                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
                 credentials: "include"
             }
         )
@@ -47,7 +47,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/login/verify`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...headers },
+                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
                 body: JSON.stringify({ cred: loginCred }),
                 credentials: "include"
             }
@@ -74,7 +74,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/register/options`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...headers },
+                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
                 body: JSON.stringify({ username: passkeyName }),
                 credentials: "include"
             }
@@ -101,7 +101,7 @@ export const toWebAuthnPubKey = async ({
             `${passkeyServerUrl}/register/verify`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...headers },
+                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
                 body: JSON.stringify({
                     userId: registerOptions.userId,
                     username: passkeyName,

--- a/plugins/weighted-r1-k1/signers/toWebAuthnSigner.ts
+++ b/plugins/weighted-r1-k1/signers/toWebAuthnSigner.ts
@@ -39,6 +39,7 @@ export type WebAuthnModularSignerParams = {
     passkeyServerUrl: string
     pubKey?: WebAuthnKey
     mode?: WebAuthnMode
+    headers?: Record<string, string>
 }
 
 export const toWebAuthnSigner = async <
@@ -50,7 +51,8 @@ export const toWebAuthnSigner = async <
         pubKey,
         passkeyServerUrl,
         passkeyName,
-        mode = WebAuthnMode.Register
+        mode = WebAuthnMode.Register,
+        headers = { "Content-Type": "application/json" }
     }: WebAuthnModularSignerParams
 ): Promise<WeightedSigner> => {
     pubKey =
@@ -58,7 +60,8 @@ export const toWebAuthnSigner = async <
         (await toWebAuthnPubKey({
             passkeyName,
             passkeyServerUrl,
-            mode
+            mode,
+            headers
         }))
     if (!pubKey) {
         throw new Error("WebAuthn public key not found")
@@ -96,7 +99,7 @@ export const toWebAuthnSigner = async <
             `${passkeyServerUrl}/sign-initiate`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json" },
+                headers,
                 body: JSON.stringify({ data: formattedMessage, userId }),
                 credentials: "include"
             }
@@ -118,7 +121,7 @@ export const toWebAuthnSigner = async <
         // verify signature from server
         const verifyResponse = await fetch(`${passkeyServerUrl}/sign-verify`, {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
+            headers,
             body: JSON.stringify({ cred, userId }),
             credentials: "include"
         })

--- a/plugins/weighted-r1-k1/signers/toWebAuthnSigner.ts
+++ b/plugins/weighted-r1-k1/signers/toWebAuthnSigner.ts
@@ -39,7 +39,7 @@ export type WebAuthnModularSignerParams = {
     passkeyServerUrl: string
     pubKey?: WebAuthnKey
     mode?: WebAuthnMode
-    headers: Record<string, string>
+    passkeyServerHeaders: Record<string, string>
 }
 
 export const toWebAuthnSigner = async <
@@ -52,7 +52,7 @@ export const toWebAuthnSigner = async <
         passkeyServerUrl,
         passkeyName,
         mode = WebAuthnMode.Register,
-        headers = {}
+        passkeyServerHeaders = {}
     }: WebAuthnModularSignerParams
 ): Promise<WeightedSigner> => {
     pubKey =
@@ -61,7 +61,7 @@ export const toWebAuthnSigner = async <
             passkeyName,
             passkeyServerUrl,
             mode,
-            headers
+            passkeyServerHeaders
         }))
     if (!pubKey) {
         throw new Error("WebAuthn public key not found")
@@ -99,7 +99,7 @@ export const toWebAuthnSigner = async <
             `${passkeyServerUrl}/sign-initiate`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...headers },
+                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
                 body: JSON.stringify({ data: formattedMessage, userId }),
                 credentials: "include"
             }
@@ -121,7 +121,7 @@ export const toWebAuthnSigner = async <
         // verify signature from server
         const verifyResponse = await fetch(`${passkeyServerUrl}/sign-verify`, {
             method: "POST",
-            headers: { "Content-Type": "application/json", ...headers },
+            headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
             body: JSON.stringify({ cred, userId }),
             credentials: "include"
         })

--- a/plugins/weighted-r1-k1/signers/toWebAuthnSigner.ts
+++ b/plugins/weighted-r1-k1/signers/toWebAuthnSigner.ts
@@ -99,7 +99,7 @@ export const toWebAuthnSigner = async <
             `${passkeyServerUrl}/sign-initiate`,
             {
                 method: "POST",
-                headers,
+                headers: { "Content-Type": "application/json", ...headers },
                 body: JSON.stringify({ data: formattedMessage, userId }),
                 credentials: "include"
             }
@@ -121,7 +121,7 @@ export const toWebAuthnSigner = async <
         // verify signature from server
         const verifyResponse = await fetch(`${passkeyServerUrl}/sign-verify`, {
             method: "POST",
-            headers,
+            headers: { "Content-Type": "application/json", ...headers },
             body: JSON.stringify({ cred, userId }),
             credentials: "include"
         })

--- a/plugins/weighted-r1-k1/signers/toWebAuthnSigner.ts
+++ b/plugins/weighted-r1-k1/signers/toWebAuthnSigner.ts
@@ -99,7 +99,10 @@ export const toWebAuthnSigner = async <
             `${passkeyServerUrl}/sign-initiate`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: {
+                    "Content-Type": "application/json",
+                    ...passkeyServerHeaders
+                },
                 body: JSON.stringify({ data: formattedMessage, userId }),
                 credentials: "include"
             }
@@ -121,7 +124,10 @@ export const toWebAuthnSigner = async <
         // verify signature from server
         const verifyResponse = await fetch(`${passkeyServerUrl}/sign-verify`, {
             method: "POST",
-            headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+            headers: {
+                "Content-Type": "application/json",
+                ...passkeyServerHeaders
+            },
             body: JSON.stringify({ cred, userId }),
             credentials: "include"
         })

--- a/plugins/weighted-r1-k1/signers/toWebAuthnSigner.ts
+++ b/plugins/weighted-r1-k1/signers/toWebAuthnSigner.ts
@@ -39,7 +39,7 @@ export type WebAuthnModularSignerParams = {
     passkeyServerUrl: string
     pubKey?: WebAuthnKey
     mode?: WebAuthnMode
-    headers?: Record<string, string>
+    headers: Record<string, string>
 }
 
 export const toWebAuthnSigner = async <

--- a/plugins/weighted-r1-k1/signers/toWebAuthnSigner.ts
+++ b/plugins/weighted-r1-k1/signers/toWebAuthnSigner.ts
@@ -52,7 +52,7 @@ export const toWebAuthnSigner = async <
         passkeyServerUrl,
         passkeyName,
         mode = WebAuthnMode.Register,
-        headers = { "Content-Type": "application/json" }
+        headers = {}
     }: WebAuthnModularSignerParams
 ): Promise<WeightedSigner> => {
     pubKey =

--- a/plugins/weighted-r1-k1/signers/toWebAuthnSigner.ts
+++ b/plugins/weighted-r1-k1/signers/toWebAuthnSigner.ts
@@ -39,7 +39,7 @@ export type WebAuthnModularSignerParams = {
     passkeyServerUrl: string
     pubKey?: WebAuthnKey
     mode?: WebAuthnMode
-    passkeyServerHeaders: Record<string, string>
+    headers: Record<string, string>
 }
 
 export const toWebAuthnSigner = async <
@@ -52,7 +52,7 @@ export const toWebAuthnSigner = async <
         passkeyServerUrl,
         passkeyName,
         mode = WebAuthnMode.Register,
-        passkeyServerHeaders = {}
+        headers = {}
     }: WebAuthnModularSignerParams
 ): Promise<WeightedSigner> => {
     pubKey =
@@ -61,7 +61,7 @@ export const toWebAuthnSigner = async <
             passkeyName,
             passkeyServerUrl,
             mode,
-            passkeyServerHeaders
+            headers
         }))
     if (!pubKey) {
         throw new Error("WebAuthn public key not found")
@@ -99,7 +99,7 @@ export const toWebAuthnSigner = async <
             `${passkeyServerUrl}/sign-initiate`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+                headers: { "Content-Type": "application/json", ...headers },
                 body: JSON.stringify({ data: formattedMessage, userId }),
                 credentials: "include"
             }
@@ -121,7 +121,7 @@ export const toWebAuthnSigner = async <
         // verify signature from server
         const verifyResponse = await fetch(`${passkeyServerUrl}/sign-verify`, {
             method: "POST",
-            headers: { "Content-Type": "application/json", ...passkeyServerHeaders },
+            headers: { "Content-Type": "application/json", ...headers },
             body: JSON.stringify({ cred, userId }),
             credentials: "include"
         })


### PR DESCRIPTION
The goal is to be more flexible with the headers sent to the passkeys server, necessary for custom passkeys server implementations.