### PR TITLE
Make passkeys server request headers optional

### DIFF
--- a/plugins/modularPermission/signers/toWebAuthnPubKey.ts
+++ b/plugins/modularPermission/signers/toWebAuthnPubKey.ts
@@ -15,7 +15,7 @@ export const toWebAuthnPubKey = async ({
     passkeyName: string
     passkeyServerUrl: string
     mode: WebAuthnMode
-    passkeyServerHeaders: Record<string, string>
+    passkeyServerHeaders?: Record<string, string>
 }): Promise<WebAuthnKey> => {
     let pubKey: string | undefined
     if (mode === WebAuthnMode.Login) {
@@ -26,7 +26,7 @@ export const toWebAuthnPubKey = async ({
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
-                    ...passkeyServerHeaders
+                    ...(passkeyServerHeaders ?? {})
                 },
                 credentials: "include"
             }
@@ -44,7 +44,7 @@ export const toWebAuthnPubKey = async ({
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
-                    ...passkeyServerHeaders
+                    ...(passkeyServerHeaders ?? {})
                 },
                 body: JSON.stringify({ cred: loginCred }),
                 credentials: "include"
@@ -74,7 +74,7 @@ export const toWebAuthnPubKey = async ({
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
-                    ...passkeyServerHeaders
+                    ...(passkeyServerHeaders ?? {})
                 },
                 body: JSON.stringify({ username: passkeyName }),
                 credentials: "include"
@@ -99,7 +99,7 @@ export const toWebAuthnPubKey = async ({
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
-                    ...passkeyServerHeaders
+                    ...(passkeyServerHeaders ?? {})
                 },
                 body: JSON.stringify({
                     userId: registerOptions.userId,

--- a/plugins/modularPermission/signers/toWebAuthnSigner.ts
+++ b/plugins/modularPermission/signers/toWebAuthnSigner.ts
@@ -36,7 +36,7 @@ export type WebAuthnModularSignerParams = ModularSignerParams & {
     passkeyServerUrl: string
     pubKey?: WebAuthnKey
     mode?: WebAuthnMode
-    passkeyServerHeaders: Record<string, string>
+    passkeyServerHeaders?: Record<string, string>
 }
 
 export const toWebAuthnSigner = async <
@@ -99,7 +99,7 @@ export const toWebAuthnSigner = async <
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
-                    ...passkeyServerHeaders
+                    ...(passkeyServerHeaders ?? {})
                 },
                 body: JSON.stringify({ data: formattedMessage, userId }),
                 credentials: "include"
@@ -123,7 +123,7 @@ export const toWebAuthnSigner = async <
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
-                ...passkeyServerHeaders
+                ...(passkeyServerHeaders ?? {})
             },
             body: JSON.stringify({ cred, userId }),
             credentials: "include"

--- a/plugins/webauthn-key/toWebAuthnKey.ts
+++ b/plugins/webauthn-key/toWebAuthnKey.ts
@@ -19,7 +19,7 @@ export type WebAuthnAccountParams = {
     webAuthnKey?: WebAuthnKey
     mode?: WebAuthnMode
     credentials?: RequestCredentials
-    passkeyServerHeaders: Record<string, string>
+    passkeyServerHeaders?: Record<string, string>
 }
 
 export const encodeWebAuthnPubKey = (pubKey: WebAuthnKey) => {
@@ -51,7 +51,7 @@ export const toWebAuthnKey = async ({
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
-                    ...passkeyServerHeaders
+                    ...(passkeyServerHeaders ?? {})
                 },
                 credentials
             }
@@ -71,7 +71,7 @@ export const toWebAuthnKey = async ({
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
-                    ...passkeyServerHeaders
+                    ...(passkeyServerHeaders ?? {})
                 },
                 body: JSON.stringify({ cred: loginCred }),
                 credentials
@@ -93,7 +93,7 @@ export const toWebAuthnKey = async ({
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
-                    ...passkeyServerHeaders
+                    ...(passkeyServerHeaders ?? {})
                 },
                 body: JSON.stringify({ username: passkeyName }),
                 credentials
@@ -114,7 +114,7 @@ export const toWebAuthnKey = async ({
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
-                    ...passkeyServerHeaders
+                    ...(passkeyServerHeaders ?? {})
                 },
                 body: JSON.stringify({
                     userId: registerOptions.userId,

--- a/plugins/weighted-r1-k1/signers/toWebAuthnPubKey.ts
+++ b/plugins/weighted-r1-k1/signers/toWebAuthnPubKey.ts
@@ -17,7 +17,7 @@ export const toWebAuthnPubKey = async ({
     passkeyName: string
     passkeyServerUrl: string
     mode: WebAuthnMode
-    passkeyServerHeaders: Record<string, string>
+    passkeyServerHeaders?: Record<string, string>
 }): Promise<WebAuthnKey> => {
     let pubKey: string | undefined
     let authenticatorIdHash: Hex
@@ -29,7 +29,7 @@ export const toWebAuthnPubKey = async ({
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
-                    ...passkeyServerHeaders
+                    ...(passkeyServerHeaders ?? {})
                 },
                 credentials: "include"
             }
@@ -52,7 +52,7 @@ export const toWebAuthnPubKey = async ({
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
-                    ...passkeyServerHeaders
+                    ...(passkeyServerHeaders ?? {})
                 },
                 body: JSON.stringify({ cred: loginCred }),
                 credentials: "include"
@@ -82,7 +82,7 @@ export const toWebAuthnPubKey = async ({
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
-                    ...passkeyServerHeaders
+                    ...(passkeyServerHeaders ?? {})
                 },
                 body: JSON.stringify({ username: passkeyName }),
                 credentials: "include"
@@ -112,7 +112,7 @@ export const toWebAuthnPubKey = async ({
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
-                    ...passkeyServerHeaders
+                    ...(passkeyServerHeaders ?? {})
                 },
                 body: JSON.stringify({
                     userId: registerOptions.userId,

--- a/plugins/weighted-r1-k1/signers/toWebAuthnSigner.ts
+++ b/plugins/weighted-r1-k1/signers/toWebAuthnSigner.ts
@@ -39,7 +39,7 @@ export type WebAuthnModularSignerParams = {
     passkeyServerUrl: string
     pubKey?: WebAuthnKey
     mode?: WebAuthnMode
-    passkeyServerHeaders: Record<string, string>
+    passkeyServerHeaders?: Record<string, string>
 }
 
 export const toWebAuthnSigner = async <
@@ -101,7 +101,7 @@ export const toWebAuthnSigner = async <
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
-                    ...passkeyServerHeaders
+                    ...(passkeyServerHeaders ?? {})
                 },
                 body: JSON.stringify({ data: formattedMessage, userId }),
                 credentials: "include"
@@ -126,7 +126,7 @@ export const toWebAuthnSigner = async <
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
-                ...passkeyServerHeaders
+                ...(passkeyServerHeaders ?? {})
             },
             body: JSON.stringify({ cred, userId }),
             credentials: "include"


### PR DESCRIPTION
Previously calls to for example `toWebAuthnKey` forced the user to provide `passkeyServerHeaders`. This was not intended. The goal was to default to an empty object without the need to explicitly do so. This PR fixes that.