### PR TITLE
Chain id lazyloading

### DIFF
--- a/packages/core/accounts/utils/toKernelPluginManager.ts
+++ b/packages/core/accounts/utils/toKernelPluginManager.ts
@@ -71,7 +71,7 @@ export async function toKernelPluginManager<
         )
     }
     const entryPointVersion = getEntryPointVersion(entryPointAddress)
-    const chainId = await getChainId(client)
+    let chainId: number;
     const activeValidator = regular || sudo
     if (!activeValidator) {
         throw new Error("One of `sudo` or `regular` validator must be set")
@@ -181,6 +181,9 @@ export async function toKernelPluginManager<
             accountAddress,
             kernelVersion
         )
+        if (!chainId) {
+            chainId = await getChainId(client)
+        }
         let ownerSig: Hex
         if (entryPointVersion === "v0.6") {
             const typeData = await getPluginsEnableTypedDataV1({
@@ -237,6 +240,9 @@ export async function toKernelPluginManager<
 
         const validatorNonce = await getKernelV3Nonce(client, accountAddress)
 
+        if (!chainId) {
+            chainId = await getChainId(client)
+        }
         const typedData = await getPluginsEnableTypedDataV2({
             accountAddress,
             chainId,

--- a/plugins/multi-chain-weighted-validator/toMultiChainWeightedValidatorPlugin.ts
+++ b/plugins/multi-chain-weighted-validator/toMultiChainWeightedValidatorPlugin.ts
@@ -125,9 +125,6 @@ export async function createMultiChainWeightedValidator<
               .sort(sortByPublicKey)
         : []
 
-    // Fetch chain id
-    const chainId = await getChainId(client)
-
     const getIndexOfSigner = () => {
         return configSigners.findIndex(
             (_signer) =>
@@ -212,6 +209,9 @@ export async function createMultiChainWeightedValidator<
                     userOperation.signature
                 ))
             }
+
+            // Fetch chain id
+            const chainId = await getChainId(client)
             // last signer signs for userOpHash
             const userOpHash = getUserOperationHash({
                 userOperation: {


### PR DESCRIPTION
In both situations identified in this PR, the sdk eagerly fetches the chain id, even though it is unclear if it'll use it.

This change makes the chain id be lazy loaded, meaning that we only fetch the chain id if we actually needed it.

This significantly improves the performance of the sdk, as we can avoid unnecessary server round trips, each of which adding latency (local tests showed ~380ms latency per request).

A concrete example:
With the multi chain weighted validator we have 1 passkey guardian and 1 ECDSA.

Without this change, everytime the passkey guardian attempts to approve a user operation, it has to wait for at least 2 server round trips fetching the chain id, even though it never calls `signUserOperation` (it calls `signTypedData` in reality) nor does it call `getSignatureData` since it is never the last signer.
