### PR TITLE
Check if a smart contract is deployed only when needed

### DIFF
--- a/packages/core/accounts/kernel/createKernelAccount.ts
+++ b/packages/core/accounts/kernel/createKernelAccount.ts
@@ -408,10 +408,7 @@ export async function createKernelAccount<
 
     if (!accountAddress) throw new Error("Account address not found")
 
-    let smartAccountDeployed = await isSmartAccountDeployed(
-        client,
-        accountAddress
-    )
+    let smartAccountDeployed: boolean | undefined;
 
     return {
         kernelVersion,
@@ -454,6 +451,12 @@ export async function createKernelAccount<
                 return encodeCallDataEpV07(tx)
             },
             async getFactory() {
+                if (smartAccountDeployed === undefined) {
+                    smartAccountDeployed = await isSmartAccountDeployed(
+                        client,
+                        accountAddress
+                    )
+                }
                 if (smartAccountDeployed) return undefined
 
                 smartAccountDeployed = await isSmartAccountDeployed(
@@ -471,6 +474,12 @@ export async function createKernelAccount<
             },
 
             async getFactoryData() {
+                if (smartAccountDeployed === undefined) {
+                    smartAccountDeployed = await isSmartAccountDeployed(
+                        client,
+                        accountAddress
+                    )
+                }
                 if (smartAccountDeployed) return undefined
 
                 smartAccountDeployed = await isSmartAccountDeployed(
@@ -589,6 +598,12 @@ export async function createKernelAccount<
 
             // Encode the init code
             async getInitCode() {
+                if (smartAccountDeployed === undefined) {
+                    smartAccountDeployed = await isSmartAccountDeployed(
+                        client,
+                        accountAddress
+                    )
+                }
                 if (smartAccountDeployed) return "0x"
 
                 smartAccountDeployed = await isSmartAccountDeployed(


### PR DESCRIPTION
In a multi chain weighted validator scenario, the passkey approver never cares about the factory data, as it's never the last signer.