### PR TITLE
fix: EIP1193 sendTransaction value input field is Hex, not BigInt

### DIFF
--- a/packages/core/providers/KernelEIP1193Provider.ts
+++ b/packages/core/providers/KernelEIP1193Provider.ts
@@ -1,8 +1,10 @@
 import { EventEmitter } from "events"
+import { hexToBigInt } from "viem"
 import type {
     EIP1193Parameters,
     EIP1193RequestFn,
     Hash,
+    Hex,
     SendTransactionParameters
 } from "viem"
 import type { KernelAccountClient } from "../clients/kernelAccountClient.js"
@@ -53,8 +55,13 @@ export class KernelEIP1193Provider extends EventEmitter {
     }
 
     private async handleEthSendTransaction(params: unknown): Promise<Hash> {
-        const [tx] = params as [SendTransactionParameters]
-        return this.kernelClient.sendTransaction(tx)
+        const [tx] = params as [
+            Omit<SendTransactionParameters, "value"> & { value?: Hex }
+        ]
+        return this.kernelClient.sendTransaction({
+            ...tx,
+            value: tx.value ? hexToBigInt(tx.value) : undefined
+        } as SendTransactionParameters)
     }
 
     private async handleEthSign(params: [string, string]): Promise<string> {


### PR DESCRIPTION
Fix `KernelEIP1193Provider`'s implementation of `eth_sendTransaction` where the value field was incorrectly processed. The value field in EIP-1193 is of type `Hex`, not `BigInt` as previously assumed. 

This caused double hex encoding when values were passed through the provider. For example, an incoming transaction with value 1 ETH (already hex-encoded as `"0xde0b6b3a7640000"`) was incorrectly treated as a string and re-encoded, resulting in the corrupted value `"0x3078646530623662336137363430303030"`.