### PR TITLE
fix: typing of serializePermissionAccount

### DIFF
--- a/.changeset/hungry-maps-punch.md
+++ b/.changeset/hungry-maps-punch.md
@@ -1,0 +1,5 @@
+---
+"@zerodev/permissions": patch
+---
+
+fix typing of serializePermissionAccount

--- a/plugins/permission/serializeMultiChainPermissionAccounts.ts
+++ b/plugins/permission/serializeMultiChainPermissionAccounts.ts
@@ -9,20 +9,24 @@ import {
     hashTypedData,
     keccak256
 } from "viem"
-import type { SmartAccount } from "viem/account-abstraction"
+import type { EntryPointVersion, SmartAccount } from "viem/account-abstraction"
 import type { PermissionPlugin } from "./types.js"
 import {
     isPermissionValidatorPlugin,
     serializePermissionAccountParams
 } from "./utils.js"
 
-export type MultiChainPermissionAccountsParams = {
-    account: SmartAccount<KernelSmartAccountImplementation>
+export type MultiChainPermissionAccountsParams<
+    entryPointVersion extends EntryPointVersion
+> = {
+    account: SmartAccount<KernelSmartAccountImplementation<entryPointVersion>>
     privateKey?: Hex
 }
 
-export const serializeMultiChainPermissionAccounts = async (
-    params: MultiChainPermissionAccountsParams[]
+export const serializeMultiChainPermissionAccounts = async <
+    entryPointVersion extends EntryPointVersion
+>(
+    params: MultiChainPermissionAccountsParams<entryPointVersion>[]
 ): Promise<string[]> => {
     if (params.length === 0) return []
 

--- a/plugins/permission/serializePermissionAccount.ts
+++ b/plugins/permission/serializePermissionAccount.ts
@@ -1,13 +1,15 @@
 import type { KernelSmartAccountImplementation } from "@zerodev/sdk"
 import type { Hex } from "viem"
-import type { SmartAccount } from "viem/account-abstraction"
+import type { EntryPointVersion, SmartAccount } from "viem/account-abstraction"
 import {
     isPermissionValidatorPlugin,
     serializePermissionAccountParams
 } from "./utils.js"
 
-export const serializePermissionAccount = async (
-    account: SmartAccount<KernelSmartAccountImplementation>,
+export const serializePermissionAccount = async <
+    entryPointVersion extends EntryPointVersion
+>(
+    account: SmartAccount<KernelSmartAccountImplementation<entryPointVersion>>,
     privateKey?: Hex,
     enableSignature?: Hex
 ): Promise<string> => {


### PR DESCRIPTION
`entryPointVersion` should be part of the `SmartAccount` definition.
